### PR TITLE
Hotfix / #8 Default empty string for null customer email

### DIFF
--- a/lib/data/local/mock_data.dart
+++ b/lib/data/local/mock_data.dart
@@ -171,7 +171,7 @@ class MockDataGenerator {
         createdByName: agents[i % agents.length].name,
         customerId: customer.id,
         customerName: customer.fullName,
-        customerEmail: customer.email,
+        customerEmail: customer.email ?? '',
         assignedAgentId: assignedAgent?.id,
         assignedAgentName: assignedAgent?.name,
         createdAt: createdDate,


### PR DESCRIPTION
Use an empty string when customer.email is null in MockDataGenerator. This prevents null values from propagating into generated mock records (which can cause issues in UI rendering or serialization) by ensuring customerEmail is always a non-null string.

closes #8 